### PR TITLE
support checkstyle lint outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,16 @@ CGO_ENABLED=0 go build -o gitea-golangci-lint
 
 There are 6 environment variables to be configured when you want to run this tool.
 
-| Variable | Description | Example |
-| --- | --- | --- |
-| `GITEA_URL` | Gitea server url | `https://try.gitea.io` |
-| `GITEA_USER` | Gitea username | `golanglinter` |
-| `GITEA_TOKEN` | Gitea access token | `your_gitea_user_accesstoken` |
-| `GITEA_REPO` | Repository name, which is inspected | `octocat/hello_world` |
-| `PULL_REQUEST` | Pull request ID | `123` |
-| `HTTP_TIMEOUT` | HTTP requests timeout in seconds | `30` |
+| Variable | Description                                            | Example                       |
+| --- |--------------------------------------------------------|-------------------------------|
+| `GITEA_URL` | Gitea server url                                       | `https://try.gitea.io`        |
+| `GITEA_USER` | Gitea username                                         | `golanglinter`                |
+| `GITEA_TOKEN` | Gitea access token                                     | `your_gitea_user_accesstoken` |
+| `GITEA_REPO` | Repository name, which is inspected                    | `octocat/hello_world`         |
+| `PULL_REQUEST` | Pull request ID                                        | `123`                         |
+| `HTTP_TIMEOUT` | HTTP requests timeout in seconds                       | `30`                          |
+| `LINT_FORMAT` | The input format from os.Stdin, default to be empty    | `empty or checkstyle`         |
+| `STATUS_CONTEXT` | The gitea's commit status context, empty will not send | `STATUS_CONTEXT`                          |
 
 ## How to use?
 
@@ -34,12 +36,12 @@ There are 6 environment variables to be configured when you want to run this too
 
 ```shell
 golangci-lint run | gitea-golangci-lint
-```
 
-### Support checkstyle input format
-
-```shell
+# Support checkstyle input format
 golangci-lint run --out-format=checkstyle | gitea-golangci-lint --format=checkstyle
+
+# Send commit check status to gitea
+golangci-lint run --out-format=checkstyle | gitea-golangci-lint --format=checkstyle --status=golangci-lint
 
 # for php lint tools
 # try below command in your composer project, you should install php-cs-fixer and phpstan first

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ There are 6 environment variables to be configured when you want to run this too
 golangci-lint run | gitea-golangci-lint
 ```
 
+### Support checkstyle input format
+
+```shell
+golangci-lint run --out-format=checkstyle | gitea-golangci-lint --format=checkstyle
+
+# for php lint tools
+# try below command in your composer project, you should install php-cs-fixer and phpstan first
+./vendor/bin/php-cs-fixer fix --config=./.php-cs-fixer.dist.php --dry-run --using-cache=no --format=checkstyle | gitea-golangci-lint --format=checkstyle
+./vendor/bin/phpstan --error-format=checkstyle | gitea-golangci-lint --format=checkstyle
+```
+
 ### Run with Drone docker pipeline
 
 Below is a drone task configuration, it may help you to config your drone task.

--- a/gitea.go
+++ b/gitea.go
@@ -11,6 +11,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	StatusSuccess = "success"
+	StatusFailure = "failure"
+)
+
 type Gitea struct {
 	BaseURL  string
 	Client   *http.Client
@@ -109,6 +114,74 @@ func (gitea Gitea) DiscardReview(repo string, pullIndex int, reviewIndex int) er
 	url := fmt.Sprintf("%s/api/v1/repos/%s/pulls/%d/reviews/%d?access_token=%s", gitea.BaseURL, repo, pullIndex, reviewIndex, gitea.Token)
 	log.Println("Discard Review: " + url)
 	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	gitea.putHeaders(req)
+	resp, err := gitea.Client.Do(req)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer resp.Body.Close()
+
+	return checkStatusCode(resp)
+}
+
+func (gitea Gitea) GetPullRequest(repo string, pullIndex int) (*PullRequest, error) {
+	url := fmt.Sprintf("%s/api/v1/repos/%s/pulls/%d?access_token=%s", gitea.BaseURL, repo, pullIndex, gitea.Token)
+	log.Println("Get PullRequest: " + url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	gitea.putHeaders(req)
+	resp, err := gitea.Client.Do(req)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer resp.Body.Close()
+	if err := checkStatusCode(resp); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	pr := &PullRequest{}
+	if err := json.Unmarshal(body, pr); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return pr, nil
+}
+
+func (gitea Gitea) SendCommitStatus(repo string, pullIndex int, ctx, status string) error {
+	pr, err := gitea.GetPullRequest(repo, pullIndex)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	stat := &CommitStatus{
+		Context:     ctx,
+		Description: fmt.Sprintf("checked this commit with %s result", status),
+		State:       status,
+		TargetURL:   fmt.Sprintf("%s/%s/pulls/%d", gitea.BaseURL, repo, pullIndex),
+	}
+	reqBody, err := json.Marshal(stat)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/repos/%s/statuses/%s?access_token=%s", gitea.BaseURL, repo, pr.Head.Sha, gitea.Token)
+	log.Println("Send Commit Status To: " + url)
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(reqBody))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/gitea_models.go
+++ b/gitea_models.go
@@ -32,3 +32,21 @@ type PullReview struct {
 	SubmittedAt    string                 `json:"submitted_at"`
 	User           map[string]interface{} `json:"user"`
 }
+
+type PullRequest struct {
+	ID        int    `json:"id"`
+	URL       string `json:"url"`
+	Number    int    `json:"number"`
+	Head      Head   `json:"head"`
+	MergeBase string `json:"merge_base"`
+}
+type Head struct {
+	Sha string `json:"sha"`
+}
+
+type CommitStatus struct {
+	Context     string `json:"context"`
+	Description string `json:"description"`
+	State       string `json:"state"`
+	TargetURL   string `json:"target_url"`
+}

--- a/linter/checkstyle.go
+++ b/linter/checkstyle.go
@@ -1,0 +1,137 @@
+package linter
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"io/ioutil"
+)
+
+// DefaultCheckStyleVersion defines the default "version" attribute on "<checkstyle>" lememnt
+var DefaultCheckStyleVersion = "1.0.0"
+
+// Severity defines a checkstyle severity code
+type Severity string
+
+var (
+	SeverityError   Severity = "error"
+	SeverityInfo    Severity = "info"
+	SeverityWarning Severity = "warning"
+	SeverityIgnore  Severity = "ignore"
+	SeverityNone    Severity
+)
+
+// CheckStyle represents a <checkstyle> xml element found in a checkstyle_report.xml file.
+type CheckStyle struct {
+	XMLName xml.Name `xml:"checkstyle"`
+	Version string   `xml:"version,attr"`
+	File    []*File  `xml:"file"`
+}
+
+// AddFile adds a checkstyle.File with the given filename.
+func (cs *CheckStyle) AddFile(csf *File) {
+	cs.File = append(cs.File, csf)
+}
+
+// GetFile gets a CheckStyleFile with the given filename.
+func (cs *CheckStyle) GetFile(filename string) (csf *File, ok bool) {
+	for _, file := range cs.File {
+		if file.Name == filename {
+			csf = file
+			ok = true
+			return
+		}
+	}
+	return
+}
+
+// EnsureFile ensures that a CheckStyleFile with the given name exists
+// Returns either an exiting CheckStyleFile (if a file with that name exists)
+// or a new CheckStyleFile (if a file with that name does not exists)
+func (cs *CheckStyle) EnsureFile(filename string) (csf *File) {
+	csf, ok := cs.GetFile(filename)
+	if !ok {
+		csf = NewFile(filename)
+		cs.AddFile(csf)
+	}
+	return csf
+}
+
+// String implements Stringer. Returns as xml.
+func (cs *CheckStyle) String() string {
+	checkStyleXML, err := xml.Marshal(cs)
+	if err != nil {
+		panic(err)
+	}
+	return string(checkStyleXML)
+}
+
+// New returns a new CheckStyle
+func New() *CheckStyle {
+	return &CheckStyle{Version: DefaultCheckStyleVersion, File: []*File{}}
+}
+
+// File represents a <file> xml element.
+type File struct {
+	XMLName xml.Name `xml:"file"`
+	Name    string   `xml:"name,attr"`
+	Error   []*Error `xml:"error"`
+}
+
+// AddError adds a checkstyle.Error to the file.
+func (csf *File) AddError(cse *Error) {
+	csf.Error = append(csf.Error, cse)
+}
+
+// NewFile creates a new checkstyle.File
+func NewFile(filename string) *File {
+	return &File{Name: filename, Error: []*Error{}}
+}
+
+// Error represents a <error> xml element
+type Error struct {
+	XMLName  xml.Name `xml:"error"`
+	Line     int      `xml:"line,attr"`
+	Column   int      `xml:"column,attr,omitempty"`
+	Severity Severity `xml:"severity,attr,omitempty"`
+	Message  string   `xml:"message,attr"`
+	Source   string   `xml:"source,attr"`
+}
+
+// NewError creates a new checkstyle.Error
+// Note that line starts at 0, and column starts at 1
+func NewError(line int, column int, severity Severity, message string, source string) *Error {
+	return &Error{Line: line, Column: column, Severity: severity, Message: message, Source: source}
+}
+
+// ParseCheckStyleFromXml Parse checkstyle xml to gitea issues.
+func ParseCheckStyleFromXml(checkStyleXML []byte) ([]Issue, error) {
+	issues := make([]Issue, 0)
+	if len(checkStyleXML) == 0 {
+		return issues, nil
+	}
+	checkStyle := New()
+	err := xml.Unmarshal(checkStyleXML, checkStyle)
+	if err == nil {
+		for _, file := range checkStyle.File {
+			for _, codingError := range file.Error {
+				issues = append(issues, Issue{
+					Filename:   file.Name,
+					LineNum:    codingError.Line,
+					Message:    codingError.Message,
+					LinterName: codingError.Source,
+				})
+			}
+		}
+	}
+	return issues, err
+}
+
+// NewCheckstyleScanner Create issues from io.Reader, eg: os.Stdin
+func NewCheckstyleScanner(r io.Reader) ([]Issue, error) {
+	readText, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stdin: %s", err)
+	}
+	return ParseCheckStyleFromXml(readText)
+}

--- a/linter/checkstyle.go
+++ b/linter/checkstyle.go
@@ -115,6 +115,10 @@ func ParseCheckStyleFromXml(checkStyleXML []byte) ([]Issue, error) {
 	if err == nil {
 		for _, file := range checkStyle.File {
 			for _, codingError := range file.Error {
+				linterName := codingError.Source
+				if linterName == "" {
+					linterName = string(codingError.Severity)
+				}
 				issues = append(issues, Issue{
 					Filename:   file.Name,
 					LineNum:    codingError.Line,

--- a/linter/checkstyle_test.go
+++ b/linter/checkstyle_test.go
@@ -1,0 +1,90 @@
+package linter
+
+import (
+	"encoding/xml"
+	"reflect"
+	"testing"
+)
+
+func TestCheckStyle(t *testing.T) {
+	xmlString := `<?xml version="1.0" encoding="UTF-8"?>
+	<checkstyle version="1.0.0">
+			<file name="/path/to/code/myfile.go">
+					<error line="2"  message="msg1" source="Ruleset.RuleName"/>
+					<error line="20"  message="msg2" source="Generic.Constant"/>
+					<error line="47"  message="msg3" source="ScopeIndent"/>
+					<error line="47" message="msg4" source="Format.MultipleAlignment"/>
+					<error line="51" message="msg5" source="Comment.FunctionComment"/>
+			</file>
+	</checkstyle>`
+
+	checkStyleElement := New()
+	err := xml.Unmarshal([]byte(xmlString), &checkStyleElement)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// <checkstyle>
+	if checkStyleElement.Version != "1.0.0" {
+		t.Error("Bad checkstyle version")
+	}
+	if len(checkStyleElement.File) != 1 {
+		t.Error("Wrong number of child <file> elements")
+	}
+
+	// <file>
+	fileElement := checkStyleElement.File[0]
+	if fileElement.Name != "/path/to/code/myfile.go" {
+		t.Error("Bad file name")
+	}
+	if len(fileElement.Error) != 5 {
+		t.Error("Wrong number of child <error> elements")
+	}
+
+	// <error>
+	errorElement := fileElement.Error[0]
+	if errorElement.Line != 2 {
+		t.Error("Bad line number")
+	}
+	if errorElement.Message != "msg1" {
+		t.Error("Bad error message")
+	}
+	if errorElement.Source != "Ruleset.RuleName" {
+		t.Error("Bad error source")
+	}
+	if errorElement.Severity != SeverityNone {
+		t.Error("Bad error Severity")
+	}
+
+	// Test round trip
+	roundtripXML := checkStyleElement.String()
+	roundtrip := New()
+	err = xml.Unmarshal([]byte(roundtripXML), &roundtrip)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(roundtrip, checkStyleElement) {
+		t.Error("Round Trip failed")
+	}
+
+}
+
+func TestBuildCheckStyle(t *testing.T) {
+	checkStyle := New()
+
+	checkfile := checkStyle.EnsureFile("path/to/file")
+
+	checkError := NewError(10, 5, SeverityError, "msg1", "test")
+	checkfile.AddError(checkError)
+
+	// Check to make sure they are the same
+	checkfileDuplicate := checkStyle.EnsureFile("path/to/file")
+	if checkfile != checkfileDuplicate {
+		t.Error("checkfile != checkfileDuplicate")
+	}
+
+	// Check the output
+	if checkStyle.String() != `<checkstyle version="1.0.0"><file name="path/to/file"><error line="10" column="5" severity="error" message="msg1" source="test"></error></file></checkstyle>` {
+		t.Error("Wrong output for String()")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 
 var app = &cli.App{
 	Name:  "gitea-golangci-lint",
-	Usage: "Sends linter outpus as pull reqeust review",
+	Usage: "Send linter outputs as pull request review",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "giteaUrl",
@@ -46,6 +46,12 @@ var app = &cli.App{
 			EnvVars: []string{"HTTP_TIMEOUT"},
 			Value:   30,
 		},
+		&cli.StringFlag{
+			Name:    "format",
+			Usage:   "Input format of lint result, value will be empty or checkstyle, default to be empty",
+			EnvVars: []string{"LINT_FORMAT"},
+			Value:   "",
+		},
 	},
 	HideVersion: true,
 	Action:      lint,
@@ -53,6 +59,7 @@ var app = &cli.App{
 
 func lint(ctx *cli.Context) error {
 	repo, pullRequestID := ctx.String("repo"), ctx.Int("pullRequest")
+	format := ctx.String("format")
 	gitea := Gitea{
 		BaseURL: strings.TrimSuffix(ctx.String("giteaUrl"), "/"),
 		Client: &http.Client{
@@ -61,14 +68,23 @@ func lint(ctx *cli.Context) error {
 		Username: ctx.String("user"),
 		Token:    ctx.String("token"),
 	}
-
 	var issues []linter.Issue
-	scanner := linter.NewLineScanner(os.Stdin)
-	for scanner.Next() {
-		issues = append(issues, scanner.Get())
-	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("scan linter output: %w", err)
+	if format == "" {
+		scanner := linter.NewLineScanner(os.Stdin)
+		for scanner.Next() {
+			issues = append(issues, scanner.Get())
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("scan linter output: %w", err)
+		}
+	} else if format == "checkstyle" {
+		var err error
+		issues, err = linter.NewCheckstyleScanner(os.Stdin)
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("format error: format value should be empty or checkstyle")
 	}
 
 	err := gitea.DiscardPreviousReviews(repo, pullRequestID)


### PR DESCRIPTION
Support checkstyle format input, so that I can use it to send issues from phpstan(larastan) and php-cs-fixer's lint result.

Thanks for this checkstyle lib from [https://github.com/phayes/checkstyle](https://github.com/phayes/checkstyle).

Also It can send commit status check result to gitea. Then gitea will show checks result like below:
<img width="873" alt="image" src="https://user-images.githubusercontent.com/1819687/160772393-6f6758ed-49e4-41c2-9c87-fbbf3e4a17db.png">

@exepirit Cloud you merge the PR and the release a new version binary file and  new docker image.
